### PR TITLE
shebang

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 import syslog


### PR DESCRIPTION
with this and `chmod +x` can just run as `sigproc` in buildroot, rather then prefixing with `python`